### PR TITLE
Add probability editing layer to sequencer lanes

### DIFF
--- a/FIRMWARE.md
+++ b/FIRMWARE.md
@@ -11,6 +11,41 @@ All lanes accumulate into a logical 10-bit range 0..1023 → mapped to 0..5 V.
 - **Clip vs Wrap:** either clamp to 0..FS or wrap (modulo full-scale)
 - **Bounce:** invert direction at boundaries for ping-pong motion
 - **Resets:** gateable resets (e.g., L1&L2; ALL)
+- **Probability layer:** second UX layer activated with the EDIT switch; lets each lane decide how often to obey its trigger
+
+### Editing layers (pot multiplexing)
+
+We keep the panel minimal by letting the same three pots serve two jobs. Flip the `EDIT LAYER` toggle low (default) to sculpt bipolar deltas; flip it high to sculpt trigger probabilities. The firmware never overwrites the "other" value while you're tweaking, so you can bounce between modes without losing your step sizes.
+
+```mermaid
+flowchart LR
+    subgraph UI[Panel Controls]
+        POT1[L1 pot]
+        POT2[L2 pot]
+        POT3[L3 pot]
+        SWITCH((Edit Layer switch))
+    end
+
+    SWITCH -- low --> DELTA["Map pot → ΔV via potToDelta()"]
+    SWITCH -- high --> PROB["Use raw 0..1023 as lane.prob"]
+
+    POT1 --> DELTA
+    POT2 --> DELTA
+    POT3 --> DELTA
+
+    POT1 --> PROB
+    POT2 --> PROB
+    POT3 --> PROB
+
+    DELTA -->|updates| LANE[(Lane.delta)]
+    PROB -->|updates| LANE2[(Lane.prob)]
+```
+
+### Probability gating 101
+
+- Each lane owns a `prob` field (0 = never, 1023 = always). We seed the RNG with the offset pot so it gets a noisy-ish startup value.
+- When a lane's trigger condition hits, we call `shouldStep()` before applying the delta. That helper pulls a 10-bit random number so the comparison is intuitive.
+- You still get all the same wrap/bounce/reset behavior; probability just says "eh, maybe not this time" before the lane moves.
 
 ## Build targets
 


### PR DESCRIPTION
## Summary
- add a new edit-layer switch to toggle pot control between step size and probability
- store per-lane trigger probabilities and gate step application accordingly
- seed the RNG during setup so probability checks produce varied output
- document the probability workflow with inline comments and expanded firmware notes

## Testing
- not run (hardware-dependent firmware)

------
https://chatgpt.com/codex/tasks/task_e_68d853800ed88325b06c63273c17c39b